### PR TITLE
fix: use full url in google search

### DIFF
--- a/layout/partials/navigation.ejs
+++ b/layout/partials/navigation.ejs
@@ -7,7 +7,7 @@
 
     <form action="http://google.com/search" method="get">
         <fieldset role="search">
-            <input type="hidden" name="q" value="site:<%- url_for() %>">
+            <input type="hidden" name="q" value="site:<%- full_url_for() %>">
             <input class="search" type="text" name="q" results="0" placeholder="Search">
         </fieldset>
     </form>


### PR DESCRIPTION
`url_for` Returns a url with the root path prefixed, which is `/`
and will make this google search `site:/ your query`

`full_url_for` Returns a url with the config.url prefixed, which is `http://www.breck-mckye.com`
and will make this google search `site:http://www.breck-mckye.com your query`

Merge this in favor of https://github.com/jbreckmckye/Blog/pull/1